### PR TITLE
Fix button layout, get rid of explicit dialog size.

### DIFF
--- a/chordIdentifierPopJazz.qml
+++ b/chordIdentifierPopJazz.qml
@@ -50,8 +50,8 @@ MuseScore {
 //    dockArea:   "left"
 //
     pluginType: "dialog"
-    width: 370
-    height: 260
+    width: radioVals.implicitWidth
+    height: radioVals.implicitHeight
     id: chordDialog
     
     Component.onCompleted : {
@@ -979,6 +979,35 @@ MuseScore {
         ]
       }
 
+      RowLayout {
+          Layout.alignment: Qt.AlignRight
+          Layout.margins: 10
+          spacing: 20
+          Button {
+              id: buttonOK
+              text: qsTr("OK")
+              width: 100
+              height: 40
+              onClicked: {
+                  showVals()
+                  curScore.startCmd()
+                  runsheet()
+                  curScore.endCmd()
+                  quit()
+              }
+          }
+
+          Button {
+              id: buttonCancel
+              text: qsTr("Cancel")
+              width: 100
+              height: 40
+              onClicked: {
+                  quit()
+              }
+          }
+      }
+
       ButtonGroup { id: rowB }
       ButtonGroup { id: rowC }
       ButtonGroup { id: rowD }
@@ -986,38 +1015,5 @@ MuseScore {
       ButtonGroup { id: rowF }
       ButtonGroup { id: rowG }
   }
-
-  Button {
-    id: buttonCancel
-    text: qsTr("Cancel")
-    anchors.bottom: chordDialog.bottom
-    anchors.right: chordDialog.right
-    anchors.bottomMargin: 10
-    anchors.rightMargin: 10
-    width: 100
-    height: 40
-    onClicked: {
-      quit();
-    }
-  }
-
-  Button {
-    id: buttonOK
-    text: qsTr("OK")
-    width: 100
-    height: 40
-    anchors.bottom: chordDialog.bottom
-    anchors.right:  buttonCancel.left
-    anchors.topMargin: 10
-    anchors.bottomMargin: 10
-    onClicked: {
-      showVals();
-      curScore.startCmd();
-      runsheet();
-      curScore.endCmd();
-      quit();
-    }
-  }
-
 }
 


### PR DESCRIPTION
In MuseScore 4.6.5, Linux, I have experienced this issue, where buttons clash with radio buttons:
<img width="390" height="314" alt="chord identifier bug" src="https://github.com/user-attachments/assets/9860b62c-f991-4b0c-801d-67576d262351" />
I have fixed the layout and made the dialog size automatic rather than explicit hardcoded values.

I was not sure if I should bump the version so I did not.
I tested it only in Linux, MuseScore 4.6.5.

Fixed it looks like this:

<img width="382" height="331" alt="fixed Screenshot_20260227_093705" src="https://github.com/user-attachments/assets/b2f64b0e-b22f-4466-9cf4-52cd50af566e" />
